### PR TITLE
fix gh-pages route after repo rename

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
-  "name": "0xhttps-web3",
+  "name": "personal",
   "private": true,
-  "homepage": "https://0xhttps.github.io/0xhttps-web3",
+  "homepage": "https://0xhttps.github.io/personal",
   "version": "0.0.0",
   "type": "module",
   "scripts": {

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -2,7 +2,7 @@ import { defineConfig } from 'vite';
 import react from '@vitejs/plugin-react';
 
 const isGithubActions = process.env.GITHUB_ACTIONS || false;
-const base = isGithubActions ? '/0xhttps-web3/' : '/';
+const base = isGithubActions ? '/personal/' : '/';
 
 export default defineConfig({
   plugins: [react()],


### PR DESCRIPTION
update build routing and `homepage` within package.json to align with repo name change